### PR TITLE
Add test on Gob

### DIFF
--- a/sqlfile_test.go
+++ b/sqlfile_test.go
@@ -1,6 +1,7 @@
 package sqlfs
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/gob"
 	"fmt"
@@ -155,6 +156,31 @@ func TestWriteAndReadGob(t *testing.T) {
 	assert.Equal(rb, rbr)
 
 	assert.NoError(r.Close())
+}
+
+func TestWriteAndReadGobLocal(t *testing.T) {
+	assert := assert.New(t)
+
+	var buf bytes.Buffer
+	// write gob
+	m := model{"unexported string", "Exported string"}
+	e := gob.NewEncoder(&buf).Encode(m)
+	assert.NoError(e)
+	// write bytes
+	rb := RandBytes(2)
+	n, e := buf.Write(rb)
+	assert.NoError(e)
+	assert.Equal(len(rb), n)
+
+	// read gob
+	var mr model
+	e = gob.NewDecoder(&buf).Decode(&mr)
+	assert.NoError(e)
+	assert.Equal(m.Exported, mr.Exported)
+	// read bytes
+	rbr, e := ioutil.ReadAll(&buf)
+	assert.NoError(e)
+	assert.Equal(rb, rbr)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
When gob and []byte are sharing the same `sqlfs` writer, the test fails. See `TestWriteAndReadGob`

When gob and []byte are sharing the same `bytes.Buffer` writer, the test DOES NOT fail. See `TestWriteAndReadGobLocal `

Contradicting to the https://github.com/wangkuiyi/sqlflow/pull/113#discussion_r237751436, looks like we can't let gob and []byte share the same writer

Error message
```
yang.y@us-192435mbp sqlfs (gob_test) $ go test -run TestWriteAndReadGob
--- FAIL: TestWriteAndReadGob (0.04s)
    sqlfile_test.go:156:
        	Error Trace:	sqlfile_test.go:156
        	Error:      	Not equal:
        	            	expected: []byte{0x56, 0x6c}
        	            	actual  : []byte{}

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,2 @@
        	            	-([]uint8) (len=2) {
        	            	- 00000000  56 6c                                             |Vl|
        	            	+([]uint8) {
        	            	 }
        	Test:       	TestWriteAndReadGob
FAIL
exit status 1
FAIL	github.com/wangkuiyi/sqlfs	0.053s
```